### PR TITLE
Fix "No rule to make target 'arch/x86/tools/relocs.c'"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DKMS_MODULES = $(DKMS_MODULES_NAME)/$(PACKAGE_VERSION)
 DKMS_SOURCE_DIR = $(DESTDIR)/usr/src/$(DKMS_MODULES_NAME)-$(PACKAGE_VERSION)
 
 modules modules_install clean:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) $@
+	$(MAKE) -C $(KDIR) M=$(shell pwd) $@
 
 depmod_conf_install:
 	install -D -m 0644 depmod.conf $(DEPMOD_CONF)


### PR DESCRIPTION
On Ubuntu 20.10, make resulted in error shown.  With a search on the issue, [StackExchange](https://askubuntu.com/questions/232840/my-makefile-results-in-no-rule-to-make-target-arch-x86-tools-relocs-c-needed) provided a workaround that was successful.